### PR TITLE
feat: disable next css modules usage

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,0 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  reactStrictMode: true,
-  output: 'standalone',
-}
-
-module.exports = nextConfig

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,16 @@
+/** @type {import('next').NextConfig} */
+import * as path from 'path';
+
+const nextConfig = {
+  reactStrictMode: true,
+  output: 'standalone',
+  webpack(config) {
+    config.module.rules[2].oneOf?.forEach((one) => {
+      if (!`${one.issuer?.and}`.includes('_app')) return;
+        one.issuer.and = [path.resolve()];
+    });
+    return config;
+  },
+}
+
+export default nextConfig


### PR DESCRIPTION
This PR allows to get rid of the `css` rules specific to `Next.js`.
Indeed, there are two possible options to apply style to our components and pages:

- put the whole `css` in the global `styles.css` file which is imported in the root of the application
- create a `css` file per component / page which respects the form `FileName.module.css` and which implies to respect a certain heavy formalism in the `classnames`.

To do this, we had to modify one of the rules so that we could use `css` files in the `portal-web` application.
The extension of the file `next.config.js` has been changed to `next.config.mjs` to allow the use of ECMAScript modules.