### PR TITLE
Fix: fix overlapping dataspace description on safari

### DIFF
--- a/src/components/dataspaceDashboard/dataspaceSummary/dataspaceSummary.scss
+++ b/src/components/dataspaceDashboard/dataspaceSummary/dataspaceSummary.scss
@@ -80,6 +80,7 @@
       display: grid;
       row-gap: 25px;
       max-height: inherit;
+      overflow-y: auto;
       @media screen and (max-width: 995px) {
         grid-area: 2/ 1 / 2 / 3;
       }
@@ -90,6 +91,7 @@
       .okp4-dataspace-selection {
         min-width: 120px;
         grid-row: 1;
+        padding-right: 2px;
         @media screen and (max-width: 995px) {
           grid-area: 2/ 1;
         }


### PR DESCRIPTION
This PR aims to fix this bug happening only on Safari:

<img width="341" alt="Capture d’écran 2022-10-18 à 18 25 33" src="https://user-images.githubusercontent.com/35332974/196488198-b385c70c-5cef-4b91-a18b-7934637df8d2.png">
