### PR TITLE
Feat/display app version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup node environment (for building)
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.0
+          node-version: 16.18
 
       - name: Fetch dependencies
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Setup node environment (for building)
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.0
+          node-version: 16.18
 
       - name: Fetch dependencies
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #-------------
-FROM node:16-alpine AS deps
+FROM node:16.18-alpine AS deps
 
 RUN apk add --no-cache libc6-compat=1.2.3-r0
 
@@ -10,7 +10,7 @@ COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile
 
 #-------------
-FROM node:16-alpine AS builder
+FROM node:16.18-alpine AS builder
 
 WORKDIR /app
 
@@ -22,7 +22,7 @@ ENV NEXT_TELEMETRY_DISABLED 1
 RUN yarn build
 
 #-------------
-FROM node:16-alpine AS runner
+FROM node:16.18-alpine AS runner
 
 WORKDIR /app
 

--- a/environment.d.ts
+++ b/environment.d.ts
@@ -10,3 +10,13 @@ declare namespace NodeJS {
     OKP4_WEBSITE_URL: string
   }
 }
+
+declare module 'next/config' {
+  declare const _default: () => {
+    publicRuntimeConfig: {
+      version: string
+    }
+  }
+
+  export default _default
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,12 @@
 /** @type {import('next').NextConfig} */
 import * as path from 'path';
+import pkg from './package.json' assert { type: "json" };
 
 const nextConfig = {
   reactStrictMode: true,
+  publicRuntimeConfig: {
+    version: pkg.version
+  },
   output: 'standalone',
   webpack(config) {
     config.module.rules[2].oneOf?.forEach((one) => {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "web": "https://okp4.network"
   },
   "engines": {
-    "node": "^16.14.0",
+    "node": "^16.18.0",
     "yarn": "~1.22.17"
   },
   "scripts": {

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react'
 import Head from 'next/head'
+import getConfig from 'next/config'
 import { Footer, Header, Logo, Typography, Icon, useTheme, useTranslation } from '@okp4/ui'
 import type { DeepReadonly, ThemeContextType, UseTranslationResponse, IconName } from '@okp4/ui'
 import lightCosmos from '@okp4/ui/lib/assets/images/cosmos-clear.png'
@@ -7,6 +8,9 @@ import darkCosmos from '@okp4/ui/lib/assets/images/cosmos-dark.png'
 import '../../i18n/index'
 import './layout.scss'
 import type { Config } from '../../pages/api/config'
+
+// eslint-disable-next-line @typescript-eslint/typedef
+const { publicRuntimeConfig } = getConfig()
 
 type LayoutProps = {
   config: Config | null
@@ -55,6 +59,7 @@ const Okp4Link = ({ label, url }: DeepReadonly<FooterLinkProps>): JSX.Element =>
       <a className="okp4-brand-link" href={url} rel="author noreferrer" target="_blank">
         ØKP4
       </a>
+      <Typography color="invariant-text" fontSize="x-small" fontWeight="xlight"> - v{publicRuntimeConfig.version}</Typography>
     </Typography>
   </Typography>
 )

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -139,6 +139,7 @@ const Layout = ({ config, children }: DeepReadonly<LayoutProps>): JSX.Element =>
           content="OKP4, Portal, Data App, Dataverse, Services, Dataset, Data Space, Deposit, Catalog, Files, Blockchain, Metadata, Exploration, Know, Token"
           name="keywords"
         />
+        <meta content={publicRuntimeConfig.version} name="version" />
         <link href="/okp4-logo.png" rel="icon" type="image/x-icon" />
       </Head>
       <div id="layout">


### PR DESCRIPTION
As a general principle, similar to [faucet-web#133](https://github.com/okp4/faucet-web/pull/133), display the version in the web app, and as additional metadata in the html header. <sub>(in order for everyone to know what version number of the app they use)</sub>

Note: Had to upgrade the version of Node to to [Node v16.18.x](https://nodejs.org/en/blog/release/v16.18.0/) LTS, as the import of JSON file in Node wasn't supported. Hope it doesn't hurt.