### PR TITLE
Feat/reverse dashboard options & entities

### DIFF
--- a/src/components/dataspaceDashboard/dataspaceEntities/dataspaceEntities.scss
+++ b/src/components/dataspaceDashboard/dataspaceEntities/dataspaceEntities.scss
@@ -1,17 +1,8 @@
 .okp4-dashboard-dataspace-content {
-  grid-row: 3;
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   gap: 25px;
   align-items: center;
-
-  @media screen and (max-width: 1300px) {
-    grid-row: 4;
-  }
-
-  @media screen and (max-width: 995px) {
-    grid-area: 4/ 1;
-  }
 
   .okp4-dataspace-card {
     display: grid;

--- a/src/components/dataspaceDashboard/dataspaceOptions/dataspaceOptions.scss
+++ b/src/components/dataspaceDashboard/dataspaceOptions/dataspaceOptions.scss
@@ -1,6 +1,14 @@
 @import '@okp4/ui/lib/scss/themes.scss';
 
 .okp4-dashboard-dataspace-options {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 25px;
+
+  @media screen and (max-width: 995px) {
+    grid-template: repeat(2, 1fr) / 1fr;
+  }
+
   .okp4-dashboard-data {
     @include with-theme() {
       display: grid;

--- a/src/components/dataspaceDashboard/dataspaceSummary/dataspaceSummary.scss
+++ b/src/components/dataspaceDashboard/dataspaceSummary/dataspaceSummary.scss
@@ -2,7 +2,6 @@
 
 .okp4-dashboard-dataspace-summary {
   @include with-theme() {
-    grid-row: 1;
     display: grid;
     gap: 40px;
     max-height: 235px;

--- a/src/pages/index.scss
+++ b/src/pages/index.scss
@@ -30,23 +30,6 @@
       @media screen and (max-width: 995px) {
         grid-column: 1;
       }
-
-      .okp4-dashboard-dataspace-options {
-        grid-row: 4;
-        display: grid;
-        grid-template-columns: repeat(2, 1fr);
-        column-gap: 25px;
-
-        @media screen and (max-width: 1300px) {
-          grid-row: 3;
-        }
-
-        @media screen and (max-width: 995px) {
-          grid-area: 3/ 1;
-          grid-template: repeat(2, 1fr) / 1fr;
-          gap: 25px;
-        }
-      }
     }
 
     .okp4-body-activity {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -33,8 +33,8 @@ export const HomePage: NextPage = () => {
             governanceUrl={dataspace.governance}
             onDataspaceChange={retrieveAndSetDataspace}
           />
-          <DataspaceEntities entities={dataspace.entities} />
           <DataspaceOptions />
+          <DataspaceEntities entities={dataspace.entities} />
         </div>
         <div className="okp4-body-activity" />
       </div>


### PR DESCRIPTION
This PR implements #52

- Makes `options` (**CAL**) stay above `entities` (**cards**) even on large screen

![Capture d’écran 2022-10-25 à 16 22 44](https://user-images.githubusercontent.com/75730728/197799809-00fb27ef-7909-4fff-8b31-30af493c279e.png)
