### PR TITLE
Add current menu to the header

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -176,13 +176,13 @@ const Layout = ({ config, children }: DeepReadonly<LayoutProps>): JSX.Element =>
   const currentMenu = useMemo(() => {
     const tmp = pathname.split('/')
 
-    return tmp.length < 3 ? '' : tmp[2]
+    return tmp.length < 3 ? 'dataverse' : tmp[2]
   }, [pathname])
 
   const navigationItems: NavigationItem[] = useMemo(() => {
     const menuItems: MenuItem[] = [
       {
-        category: 'home',
+        category: 'dataverse',
         namespace: 'header:home',
         url: homeUrl
       },

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -2,6 +2,8 @@ import React, { useMemo } from 'react'
 import Head from 'next/head'
 import Link from 'next/link'
 import getConfig from 'next/config'
+import type { NextRouter } from 'next/router'
+import { useRouter } from 'next/router'
 import { Footer, Header, Logo, Typography, Icon, useTheme, useTranslation } from '@okp4/ui'
 import type {
   DeepReadonly,
@@ -58,6 +60,7 @@ type NavigationMenuUrls = {
 }
 
 type MenuItem = {
+  category: string
   namespace: string
   url: string | undefined
 }
@@ -169,47 +172,62 @@ const Layout = ({ config, children }: DeepReadonly<LayoutProps>): JSX.Element =>
     learnUrl: undefined,
     okp4Url: undefined
   }
+  const { pathname }: NextRouter = useRouter()
+  const currentMenu = useMemo(() => {
+    const tmp = pathname.split('/')
+
+    return tmp.length < 3 ? '' : tmp[2]
+  }, [pathname])
 
   const navigationItems: NavigationItem[] = useMemo(() => {
     const menuItems: MenuItem[] = [
       {
+        category: 'home',
         namespace: 'header:home',
         url: homeUrl
       },
       {
+        category: 'create',
         namespace: 'header:create',
         url: createUrl
       },
       {
+        category: 'explore',
         namespace: 'header:explore',
         url: exploreUrl
       },
       {
+        category: 'interact',
         namespace: 'header:interact',
         url: interactUrl
       },
       {
+        category: 'learn',
         namespace: 'header:learn',
         url: learnUrl
       },
       {
+        category: 'okp4',
         namespace: 'header:okp4',
         url: okp4Url
       }
     ]
 
-    return menuItems.map(({ url, namespace }: DeepReadonly<MenuItem>, index: number) => ({
-      menuItem: (
-        <Typography as="div" fontSize="small" fontWeight="bold" key={index} noWrap>
-          {url && isExternalUrl(url) ? (
-            <a href={url}>{t(namespace)}</a>
-          ) : (
-            <Link href={{ pathname: url }}>{t(namespace)}</Link>
-          )}
-        </Typography>
-      )
-    }))
-  }, [homeUrl, createUrl, exploreUrl, interactUrl, learnUrl, okp4Url, t])
+    return menuItems.map(
+      ({ url, namespace, category }: DeepReadonly<MenuItem>, index: number): NavigationItem => ({
+        menuItem: (
+          <Typography as="div" fontSize="small" fontWeight="bold" key={index} noWrap>
+            {url && isExternalUrl(url) ? (
+              <a href={url}>{t(namespace)}</a>
+            ) : (
+              <Link href={{ pathname: url }}>{t(namespace)}</Link>
+            )}
+          </Typography>
+        ),
+        isSelectedFromStart: category === currentMenu
+      })
+    )
+  }, [homeUrl, currentMenu, createUrl, exploreUrl, interactUrl, learnUrl, okp4Url, t])
 
   return (
     <>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -60,7 +60,7 @@ type NavigationMenuUrls = {
 }
 
 type MenuItem = {
-  category: string
+  subdirectory: string
   namespace: string
   url: string | undefined
 }
@@ -173,48 +173,52 @@ const Layout = ({ config, children }: DeepReadonly<LayoutProps>): JSX.Element =>
     okp4Url: undefined
   }
   const { pathname }: NextRouter = useRouter()
-  const currentMenu = useMemo(() => {
-    const tmp = pathname.split('/')
+  const currentSubdirectory = useMemo(() => {
+    const subdirectories = pathname.split('/')
 
-    return tmp.length < 3 ? 'dataverse' : tmp[2]
+    return subdirectories.length < 3 ? 'dataverse' : subdirectories[2]
   }, [pathname])
 
+  // eslint-disable-next-line max-lines-per-function
   const navigationItems: NavigationItem[] = useMemo(() => {
     const menuItems: MenuItem[] = [
       {
-        category: 'dataverse',
+        subdirectory: 'dataverse',
         namespace: 'header:home',
         url: homeUrl
       },
       {
-        category: 'create',
+        subdirectory: 'create',
         namespace: 'header:create',
         url: createUrl
       },
       {
-        category: 'explore',
+        subdirectory: 'explore',
         namespace: 'header:explore',
         url: exploreUrl
       },
       {
-        category: 'interact',
+        subdirectory: 'interact',
         namespace: 'header:interact',
         url: interactUrl
       },
       {
-        category: 'learn',
+        subdirectory: 'learn',
         namespace: 'header:learn',
         url: learnUrl
       },
       {
-        category: 'okp4',
+        subdirectory: 'okp4',
         namespace: 'header:okp4',
         url: okp4Url
       }
     ]
 
     return menuItems.map(
-      ({ url, namespace, category }: DeepReadonly<MenuItem>, index: number): NavigationItem => ({
+      (
+        { url, namespace, subdirectory }: DeepReadonly<MenuItem>,
+        index: number
+      ): NavigationItem => ({
         menuItem: (
           <Typography as="div" fontSize="small" fontWeight="bold" key={index} noWrap>
             {url && isExternalUrl(url) ? (
@@ -224,10 +228,10 @@ const Layout = ({ config, children }: DeepReadonly<LayoutProps>): JSX.Element =>
             )}
           </Typography>
         ),
-        isSelectedFromStart: category === currentMenu
+        isSelectedFromStart: subdirectory === currentSubdirectory
       })
     )
-  }, [homeUrl, currentMenu, createUrl, exploreUrl, interactUrl, learnUrl, okp4Url, t])
+  }, [homeUrl, currentSubdirectory, createUrl, exploreUrl, interactUrl, learnUrl, okp4Url, t])
 
   return (
     <>


### PR DESCRIPTION
Before this PR, if you refresh the page, the current menu won't be selected in the header. This PR fixes it. The fix is only set for top level menus.