### PR TITLE
fix: go to canonical config fetching for dataspaces

### DIFF
--- a/src/pages/api/config.ts
+++ b/src/pages/api/config.ts
@@ -20,6 +20,7 @@ export type Config = {
       twitterUrl: string
     }
     apiUri: string
+    defaultDataspaceId: string
     okp4BiUrl: string
   }
   chain: {
@@ -58,6 +59,7 @@ export default function handler(_req: NextApiRequest, res: NextApiResponse<Confi
         twitterUrl: process.env.OKP4_TWITTER_URL
       },
       apiUri: process.env.API_URI,
+      defaultDataspaceId: process.env.DEFAULT_DATASPACE_ID,
       okp4BiUrl: process.env.OKP4_BI_URL
     },
     chain: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -739,11 +739,6 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/node@18.11.8":
-  version "18.11.8"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.8.tgz#16d222a58d4363a2a359656dd20b28414de5d265"
-  integrity sha512-uGwPWlE0Hj972KkHtCDVwZ8O39GmyjfMane1Z3GUBGGnkZ2USDq7SxLpVIiIHpweY9DS0QTDH0Nw7RNBsAAZ5A==
-  
 "@types/long@^4.0.1":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
@@ -758,6 +753,11 @@
   version "18.11.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.8.tgz#16d222a58d4363a2a359656dd20b28414de5d265"
   integrity sha512-uGwPWlE0Hj972KkHtCDVwZ8O39GmyjfMane1Z3GUBGGnkZ2USDq7SxLpVIiIHpweY9DS0QTDH0Nw7RNBsAAZ5A==
+
+"@types/node@>=13.7.0":
+  version "18.11.9"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
+  integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
 
 "@types/node@^13.7.0":
   version "13.13.52"


### PR DESCRIPTION
Due to the issues encountered during the deployment regarding the fetching of dataspaces on the server side, this PR adopt the canonical approch using a backend query.