### PR TITLE
Feat/governance page

### DIFF
--- a/data/dataspace.json
+++ b/data/dataspace.json
@@ -11,7 +11,96 @@
     "members": 1178,
     "datasets": 822,
     "services": 674,
-    "governanceUrl": "https://xd.adobe.com/view/31a3d2a5-9f07-4e31-a612-20059ff929a5-64f0/screen/d8a45cb1-7433-40b3-b6ce-4237bfcd0678/?fullscreen",
+    "governance": {
+      "accessControl": [
+        {
+          "subCategory": "data spaces",
+          "rules": [
+            {
+              "title": "authentication",
+              "rule": "Login with wallet"
+            }
+          ]
+        },
+        {
+          "subCategory": "datasets",
+          "rules": [
+            {
+              "title": "uploading",
+              "rule": "User is authenticated"
+            }
+          ]
+        }
+      ],
+      "dataManagement": [
+        {
+          "rules": [
+            {
+              "title": "field",
+              "rule": "Agriculture or food"
+            },
+            {
+              "title": "size",
+              "rule": "Smaller than 5 GB"
+            },
+            {
+              "title": "licence",
+              "rule": "Etalab-2.0, 0GL, CC-BY 2.0, ODC-BY or 0Dbl 1.0"
+            },
+            {
+              "title": "geographical area",
+              "rule": "Metropolitan France, French Overseas Territories or Europe"
+            },
+            {
+              "title": "metadata",
+              "rule": "To be specified"
+            },
+            {
+              "title": "authorship",
+              "rule": "To be specified"
+            },
+            {
+              "title": "personal data",
+              "rule": "To be excluded"
+            }
+          ]
+        }
+      ],
+      "serviceManagement": [
+        {
+          "rules": [
+            {
+              "title": "language",
+              "rule": "English or French"
+            }
+          ]
+        }
+      ],
+      "businessModel": [
+        {
+          "rules": [
+            {
+              "title": "open",
+              "rule": "Demonstrator available for free"
+            }
+          ]
+        }
+      ],
+      "governance": [
+        {
+          "rules": [
+            {
+              "title": "can modify",
+              "rule": "OKP4"
+            },
+            {
+              "title": "can moderate",
+              "rule": "OKP4"
+            }
+          ]
+        }
+      ]
+    },
     "createdOn": "2022-10-30T15:29:16.507Z",
     "updatedOn": "2022-10-30T15:29:16.507Z"
   },
@@ -27,7 +116,96 @@
     "members": 945,
     "datasets": 745,
     "services": 520,
-    "governanceUrl": "https://xd.adobe.com/view/31a3d2a5-9f07-4e31-a612-20059ff929a5-64f0/screen/d8a45cb1-7433-40b3-b6ce-4237bfcd0678/?fullscreen",
+    "governance": {
+      "accessControl": [
+        {
+          "subCategory": "data spaces",
+          "rules": [
+            {
+              "title": "authentication",
+              "rule": "Login with wallet"
+            }
+          ]
+        },
+        {
+          "subCategory": "datasets",
+          "rules": [
+            {
+              "title": "uploading",
+              "rule": "User is authenticated"
+            }
+          ]
+        }
+      ],
+      "dataManagement": [
+        {
+          "rules": [
+            {
+              "title": "field",
+              "rule": "Agriculture or food"
+            },
+            {
+              "title": "size",
+              "rule": "Smaller than 5 GB"
+            },
+            {
+              "title": "licence",
+              "rule": "Etalab-2.0, 0GL, CC-BY 2.0, ODC-BY or 0Dbl 1.0"
+            },
+            {
+              "title": "geographical area",
+              "rule": "Metropolitan France, French Overseas Territories or Europe"
+            },
+            {
+              "title": "metadata",
+              "rule": "To be specified"
+            },
+            {
+              "title": "authorship",
+              "rule": "To be specified"
+            },
+            {
+              "title": "personal data",
+              "rule": "To be excluded"
+            }
+          ]
+        }
+      ],
+      "serviceManagement": [
+        {
+          "rules": [
+            {
+              "title": "language",
+              "rule": "English or French"
+            }
+          ]
+        }
+      ],
+      "businessModel": [
+        {
+          "rules": [
+            {
+              "title": "open",
+              "rule": "Demonstrator available for free"
+            }
+          ]
+        }
+      ],
+      "governance": [
+        {
+          "rules": [
+            {
+              "title": "can modify",
+              "rule": "OKP4"
+            },
+            {
+              "title": "can moderate",
+              "rule": "OKP4"
+            }
+          ]
+        }
+      ]
+    },
     "createdOn": "2022-10-30T15:29:16.507Z",
     "updatedOn": "2022-10-30T15:29:16.507Z"
   }

--- a/src/components/dataset/datasetInformation/DatasetInformation.tsx
+++ b/src/components/dataset/datasetInformation/DatasetInformation.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import Image from 'next/image'
 import { Button, Icon, Typography, useTheme, useTranslation } from '@okp4/ui'
 import type { DeepReadonly, ThemeContextType, UseState, UseTranslationResponse } from '@okp4/ui'
@@ -6,6 +6,7 @@ import { formatBytes, formatDate } from '../../../utils'
 import type { DatasetDto } from '../../../dto/DatasetDto'
 import type { DataspaceDto } from '../../../dto/DataspaceDto'
 import { Graphviz } from 'graphviz-react'
+import { useRouter } from 'next/router'
 
 type DatasetInformationProps = {
   readonly dataset: DatasetDto
@@ -21,6 +22,7 @@ type GovernanceProps = {
   readonly name: string
   readonly theme: string
   readonly token: string
+  readonly dataspace: string
 }
 
 type MetadataProps = {
@@ -54,8 +56,18 @@ const Container = ({ children, name }: DeepReadonly<ContainerProps>): JSX.Elemen
   </div>
 )
 
-const Governance = ({ name, theme, token }: DeepReadonly<GovernanceProps>): JSX.Element => {
+const Governance = ({
+  name,
+  theme,
+  token,
+  dataspace
+}: DeepReadonly<GovernanceProps>): JSX.Element => {
   const { t }: UseTranslationResponse = useTranslation()
+  const router = useRouter()
+
+  const navigateToGovernance = useCallback(() => {
+    router.push(`/dataverse/dataspace/${dataspace}/governance`)
+  }, [dataspace, router])
 
   return (
     <div className="okp4-dataset-governance">
@@ -66,6 +78,7 @@ const Governance = ({ name, theme, token }: DeepReadonly<GovernanceProps>): JSX.
         // TODO: Should be removed with the next design system evolution of the okp4/ui
         backgroundColor={theme === 'dark' ? 'secondary' : 'primary'}
         label={t('dataset:governance:view')}
+        onClick={navigateToGovernance}
       />
     </div>
   )
@@ -185,7 +198,12 @@ const DatasetInformation = ({
         </Container>
         {dataspace && (
           <Container name={t('dataset:governance:name')}>
-            <Governance name={dataspace.name} theme={theme} token={dataspace.token} />
+            <Governance
+              dataspace={dataspace.id}
+              name={dataspace.name}
+              theme={theme}
+              token={dataspace.token}
+            />
           </Container>
         )}
         <Container name={t('dataset:metadata')}>

--- a/src/components/dataspace/governance/governanceSummary/GovernanceSummary.tsx
+++ b/src/components/dataspace/governance/governanceSummary/GovernanceSummary.tsx
@@ -1,0 +1,75 @@
+import { Typography, useTheme, useTranslation } from '@okp4/ui'
+import type { DeepReadonly, ThemeContextType, UseTranslationResponse } from '@okp4/ui'
+import classNames from 'classnames'
+import type { Governance, GovernanceContent, Rule } from '../../../../dto/DataspaceDto'
+
+type GovernanceSummaryProps = DeepReadonly<{
+  governance: Governance
+  dataspaceName: string
+}>
+
+// eslint-disable-next-line max-lines-per-function
+const GovernanceSummary = ({ governance, dataspaceName }: GovernanceSummaryProps): JSX.Element => {
+  const { theme }: ThemeContextType = useTheme()
+  const { t }: UseTranslationResponse = useTranslation()
+
+  return (
+    <div className="okp4-governance-summary-main">
+      <Typography as="h1" color="highlighted-text" fontSize="large">
+        {t(`governance:title`, { dataspace: dataspaceName })}
+      </Typography>
+
+      {Object.entries(governance).map(
+        ([category, content]: DeepReadonly<[string, GovernanceContent[]]>, index: number) => (
+          <div className="okp4-governance-summary-category" key={index}>
+            <div className={classNames('okp4-governance-summary-title', theme)}>
+              <Typography
+                color={theme === 'dark' ? 'inverted-text' : 'invariant-text'}
+                fontSize="small"
+                fontWeight="bold"
+              >
+                {t(`governance:categories:${category}`).toUpperCase()}
+              </Typography>
+            </div>
+            <div className="okp4-governance-summary-content">
+              {content.map(
+                ({ subCategory, rules }: DeepReadonly<GovernanceContent>, index: number) => (
+                  <div key={index}>
+                    {subCategory && (
+                      <>
+                        <Typography fontFamily="secondary" fontSize="small">
+                          {subCategory.toUpperCase()}
+                        </Typography>
+                        <div className="okp4-governance-summary-line-separator" />
+                      </>
+                    )}
+                    <div className="okp4-governance-summary-items">
+                      {rules.map(({ title, rule }: DeepReadonly<Rule>, index: number) => (
+                        <div
+                          className={classNames('okp4-governance-summary-item', theme)}
+                          key={index}
+                        >
+                          <Typography color="highlighted-text" fontSize="small" fontWeight="bold">
+                            {title.toUpperCase()}
+                          </Typography>
+                          <div
+                            className={classNames('okp4-governance-summary-line-separator', 'item')}
+                          />
+                          <Typography as="p" fontSize="small">
+                            {rule}
+                          </Typography>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )
+              )}
+            </div>
+          </div>
+        )
+      )}
+    </div>
+  )
+}
+
+export default GovernanceSummary

--- a/src/components/dataspace/governance/governanceSummary/governanceSummary.scss
+++ b/src/components/dataspace/governance/governanceSummary/governanceSummary.scss
@@ -1,0 +1,78 @@
+@import '@okp4/ui/lib/scss/themes';
+
+.okp4-governance-summary-main {
+  @include with-theme {
+    margin-bottom: 130px;
+
+    .okp4-governance-summary-title {
+      border-radius: 5px;
+      padding: 20px 20px 20px 0;
+
+      &.dark {
+        background: themed(info);
+      }
+
+      &.light {
+        background: themed('secondary-background');
+      }
+
+      span {
+        margin-left: 30px;
+      }
+    }
+
+    .okp4-governance-summary-content {
+      margin: 40px 0 0 30px;
+
+      h3 {
+        word-spacing: -0.3em;
+      }
+
+      .okp4-governance-summary-line-separator {
+        height: 1px;
+        background: themed(info);
+        opacity: 0.5;
+        margin: 2px 0;
+
+        &.item {
+          background: themed('warning');
+        }
+      }
+
+      .okp4-governance-summary-items {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(315px, 1fr));
+        gap: 25px;
+        margin: 20px 15px;
+
+        .okp4-governance-summary-item {
+          border-radius: 10px;
+          padding: 13px 30px 13px 13px;
+          max-width: 380px;
+
+          &.dark {
+            background-color: themed('secondary-button');
+          }
+
+          &.light {
+            background-color: themed('border');
+          }
+        }
+      }
+    }
+
+    @media screen and (max-width: 860px) {
+      .okp4-governance-summary-content {
+        .okp4-governance-summary-items {
+          grid-template-columns: repeat(auto-fill, minmax(270px, 1fr));
+        }
+      }
+    }
+
+    @media screen and (max-width: 650px) {
+      .okp4-governance-summary-content {
+        margin: 40px 0 0;
+      }
+    }
+  }
+}

--- a/src/components/dataspaceDashboard/dataspaceSummary/DataspaceSummary.tsx
+++ b/src/components/dataspaceDashboard/dataspaceSummary/DataspaceSummary.tsx
@@ -89,9 +89,8 @@ const DataspaceSummary = ({
   )
 
   const navigateToGovernance = useCallback(() => {
-    selectedDataspace.governanceUrl &&
-      router.push(`/dataverse/dataspace/${selectedDataspace.id}/governance`)
-  }, [selectedDataspace.governanceUrl, selectedDataspace.id, router])
+    router.push(`/dataverse/dataspace/${selectedDataspace.id}/governance`)
+  }, [selectedDataspace.id, router])
 
   const handleCreateDataspaceClick = useCallback(
     () => createDataspaceUrl && router.push(createDataspaceUrl),
@@ -139,7 +138,7 @@ const DataspaceSummary = ({
       </div>
       <div className="okp4-dashboard-governance-link">
         <Button
-          disabled={!selectedDataspace.governanceUrl}
+          disabled={!selectedDataspace.governance}
           label={t(`dashboard:dataspace:governance`, { dataspace: selectedDataspace.name })}
           onClick={navigateToGovernance}
         />

--- a/src/components/dataspaceDashboard/dataspaceSummary/DataspaceSummary.tsx
+++ b/src/components/dataspaceDashboard/dataspaceSummary/DataspaceSummary.tsx
@@ -89,8 +89,9 @@ const DataspaceSummary = ({
   )
 
   const navigateToGovernance = useCallback(() => {
-    selectedDataspace.governanceUrl && router.push(selectedDataspace.governanceUrl)
-  }, [selectedDataspace.governanceUrl, router])
+    selectedDataspace.governanceUrl &&
+      router.push(`/dataverse/dataspace/${selectedDataspace.id}/governance`)
+  }, [selectedDataspace.governanceUrl, selectedDataspace.id, router])
 
   const handleCreateDataspaceClick = useCallback(
     () => createDataspaceUrl && router.push(createDataspaceUrl),

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -33,9 +33,12 @@ const ExploreList = dynamic(async () => import('./explore/exploreList/ExploreLis
   ssr: false
 })
 
-export const PreviousPageButton = dynamic(async () => import('./previousPageButton/PreviousPageButton'), {
-  ssr: false
-})
+export const PreviousPageButton = dynamic(
+  async () => import('./previousPageButton/PreviousPageButton'),
+  {
+    ssr: false
+  }
+)
 
 export const DatasetPreview = dynamic(
   async () => import('./dataset/datasetPreview/DatasetPreview'),
@@ -55,6 +58,13 @@ const ExploreFilters = dynamic(async () => import('./explore/exploreFilters/Expl
 
 export const DatasetInformation = dynamic(
   async () => import('./dataset/datasetInformation/DatasetInformation'),
+  {
+    ssr: false
+  }
+)
+
+export const GovernanceSummary = dynamic(
+  async () => import('./dataspace/governance/governanceSummary/GovernanceSummary'),
   {
     ssr: false
   }

--- a/src/components/previousPageButton/PreviousPageButton.tsx
+++ b/src/components/previousPageButton/PreviousPageButton.tsx
@@ -1,24 +1,47 @@
-import { Button, Icon, useTranslation } from '@okp4/ui'
-import type { UseTranslationResponse } from '@okp4/ui'
+import { Button, Icon, Typography, useTranslation } from '@okp4/ui'
+import type { DeepReadonly, UseTranslationResponse } from '@okp4/ui'
 import { useRouter } from 'next/router'
 import type { NextRouter } from 'next/router'
 import { useCallback } from 'react'
+import classNames from 'classnames'
 
-export const PreviousPageButton = (): JSX.Element => {
+type PreviousPageButtonProps = DeepReadonly<{
+  variant?: 'squared' | 'round'
+}>
+
+export const PreviousPageButton = ({
+  variant = 'squared'
+}: PreviousPageButtonProps): JSX.Element => {
   const router: NextRouter = useRouter()
   const { t }: UseTranslationResponse = useTranslation()
+  const label = t('dataset:back')
 
   const handlePreviousPageClick = useCallback((): void => {
     router.back()
   }, [router])
 
   return (
-    <div className="okp4-previous-page-button">
-      <Button
-        label={t('dataset:back')}
-        leftIcon={<Icon name="arrow-left" size={22} />}
-        onClick={handlePreviousPageClick}
-      />
+    <div className={classNames('okp4-previous-page-button', variant)}>
+      {variant === 'squared' ? (
+        <Button
+          label={label}
+          leftIcon={<Icon name="arrow-left" size={22} />}
+          onClick={handlePreviousPageClick}
+        />
+      ) : (
+        <>
+          <Button
+            backgroundColor="info"
+            icon={<Icon invertColor name="arrow-left" />}
+            label={label}
+            onClick={handlePreviousPageClick}
+            variant="icon"
+          />
+          <Typography fontSize="small" noWrap>
+            {label}
+          </Typography>
+        </>
+      )}
     </div>
   )
 }

--- a/src/components/previousPageButton/previousPageButton.scss
+++ b/src/components/previousPageButton/previousPageButton.scss
@@ -1,0 +1,8 @@
+.okp4-previous-page-button {
+  &.round {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    align-items: center;
+  }
+}

--- a/src/dto/DataspaceDto.ts
+++ b/src/dto/DataspaceDto.ts
@@ -1,6 +1,24 @@
+export type Rule = {
+  title: string
+  rule: string
+}
+
+export type GovernanceContent = {
+  subCategory?: string
+  rules: Rule[]
+}
+
+export type Governance = {
+  accessControl: GovernanceContent[]
+  dataManagement: GovernanceContent[]
+  serviceManagement: GovernanceContent[]
+  businessModel: GovernanceContent[]
+  governance: GovernanceContent[]
+}
+
 export type DataspaceDto = {
   id: string
-  type: "dataspace"
+  type: 'dataspace'
   name: string
   access: string
   creator: string
@@ -10,7 +28,7 @@ export type DataspaceDto = {
   members: number
   datasets: number
   services: number
-  governanceUrl: string | null
+  governance: Governance
   createdOn: string
   updatedOn: string
 }

--- a/src/i18n/governance/governance_en.json
+++ b/src/i18n/governance/governance_en.json
@@ -1,0 +1,10 @@
+{
+  "title": "{{dataspace}} governance",
+  "categories": {
+    "accessControl": "access control",
+    "dataManagement": "data management",
+    "serviceManagement": "service management",
+    "businessModel": "business model",
+    "governance": "governance"
+  }
+}

--- a/src/i18n/governance/governance_fr.json
+++ b/src/i18n/governance/governance_fr.json
@@ -1,0 +1,10 @@
+{
+  "title": "Gouvernance {{dataspace}}",
+  "categories": {
+    "accessControl": "contrôle d'accès",
+    "dataManagement": "gestion de données",
+    "serviceManagement": "gestion de services",
+    "businessModel": "modèle d'affaires",
+    "governance": "gouvernance"
+  }
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -9,6 +9,8 @@ import explore_en from './explore/explore_en.json'
 import explore_fr from './explore/explore_fr.json'
 import dataset_en from './dataset/dataset_en.json'
 import dataset_fr from './dataset/dataset_fr.json'
+import governance_en from './governance/governance_en.json'
+import governance_fr from './governance/governance_fr.json'
 
 const translationsToLoad = [
   { lng: 'en', namespace: 'header', resource: header_en },
@@ -21,6 +23,8 @@ const translationsToLoad = [
   { lng: 'fr', namespace: 'footer', resource: footer_fr },
   { lng: 'en', namespace: 'dataset', resource: dataset_en },
   { lng: 'fr', namespace: 'dataset', resource: dataset_fr },
+  { lng: 'en', namespace: 'governance', resource: governance_en },
+  { lng: 'fr', namespace: 'governance', resource: governance_fr }
 ]
 
 loadTranslations(translationsToLoad)

--- a/src/pages/dataverse/dataspace/[dataspaceId]/governance/governance.scss
+++ b/src/pages/dataverse/dataspace/[dataspaceId]/governance/governance.scss
@@ -1,0 +1,4 @@
+.okp4-governance-main {
+  max-width: 1340px;
+  margin: auto;
+}

--- a/src/pages/dataverse/dataspace/[dataspaceId]/governance/index.tsx
+++ b/src/pages/dataverse/dataspace/[dataspaceId]/governance/index.tsx
@@ -7,14 +7,21 @@ import type {
   GetStaticPropsResult,
   NextPage
 } from 'next'
+import { GovernanceSummary } from '../../../../../components'
 import type { DataspaceDto } from '../../../../../dto/DataspaceDto'
 
 type GovernanceProps = {
   dataspace: DataspaceDto | null
 }
 
-const Governance: NextPage<GovernanceProps> = () => {
-  return <div className="okp4-governance-main"></div>
+const Governance: NextPage<GovernanceProps> = ({ dataspace }: DeepReadonly<GovernanceProps>) => {
+  return (
+    <div className="okp4-governance-main">
+      {dataspace && (
+        <GovernanceSummary dataspaceName={dataspace.name} governance={dataspace.governance} />
+      )}
+    </div>
+  )
 }
 
 export default Governance

--- a/src/pages/dataverse/dataspace/[dataspaceId]/governance/index.tsx
+++ b/src/pages/dataverse/dataspace/[dataspaceId]/governance/index.tsx
@@ -1,0 +1,45 @@
+import type { DeepReadonly } from '@okp4/ui'
+import type {
+  GetStaticPaths,
+  GetStaticPathsResult,
+  GetStaticProps,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+  NextPage
+} from 'next'
+import type { DataspaceDto } from '../../../../../dto/DataspaceDto'
+
+type GovernanceProps = {
+  dataspace: DataspaceDto | null
+}
+
+const Governance: NextPage<GovernanceProps> = () => {
+  return <div className="okp4-governance-main"></div>
+}
+
+export default Governance
+
+export const getStaticPaths: GetStaticPaths = async (): Promise<GetStaticPathsResult> => {
+  return {
+    paths: [],
+    fallback: true
+  }
+}
+
+export const getStaticProps: GetStaticProps = async ({
+  params
+}: DeepReadonly<GetStaticPropsContext>): Promise<
+  GetStaticPropsResult<Omit<GovernanceProps, 'config'>>
+> => {
+  const dataspaceId = params?.dataspaceId
+
+  const dataspaceResponse = await fetch(`${process.env.API_URI}/dataverse/dataspace/${dataspaceId}`)
+
+  const dataspace: DataspaceDto | null = dataspaceResponse.ok
+    ? await dataspaceResponse.json()
+    : null
+
+  return {
+    props: { dataspace }
+  }
+}

--- a/src/pages/dataverse/dataspace/[dataspaceId]/governance/index.tsx
+++ b/src/pages/dataverse/dataspace/[dataspaceId]/governance/index.tsx
@@ -7,7 +7,7 @@ import type {
   GetStaticPropsResult,
   NextPage
 } from 'next'
-import { GovernanceSummary } from '../../../../../components'
+import { GovernanceSummary, PreviousPageButton } from '../../../../../components'
 import type { DataspaceDto } from '../../../../../dto/DataspaceDto'
 
 type GovernanceProps = {
@@ -20,6 +20,7 @@ const Governance: NextPage<GovernanceProps> = ({ dataspace }: DeepReadonly<Gover
       {dataspace && (
         <GovernanceSummary dataspaceName={dataspace.name} governance={dataspace.governance} />
       )}
+      <PreviousPageButton variant="round" />
     </div>
   )
 }

--- a/src/pages/styles.scss
+++ b/src/pages/styles.scss
@@ -6,11 +6,13 @@
 @import '/src/components/explore/exploreFilters/ExploreFilters.scss';
 @import '/src/components/explore/exploreList/exploreList.scss';
 @import '/src/components/explore/exploreListConfiguration/exploreListConfiguration.scss';
+@import '/src/components/dataspace/governance/governanceSummary/governanceSummary.scss';
 @import '/src/components/layout/layout.scss';
 @import '/src/components/pageTitle/pageTitle.scss';
 @import '/src/pages/dataverse/index.scss';
 @import '/src/pages/dataverse/explore/explore.scss';
 @import '/src/pages/dataverse/explore/dataspace/[dataspaceId]/dataset/datasetId.scss';
+@import '/src/pages/dataverse/dataspace/[dataspaceId]/governance/governance.scss';
 
 html,
 body {

--- a/src/pages/styles.scss
+++ b/src/pages/styles.scss
@@ -8,6 +8,7 @@
 @import '/src/components/explore/exploreListConfiguration/exploreListConfiguration.scss';
 @import '/src/components/dataspace/governance/governanceSummary/governanceSummary.scss';
 @import '/src/components/layout/layout.scss';
+@import '/src/components/previousPageButton/previousPageButton.scss';
 @import '/src/components/pageTitle/pageTitle.scss';
 @import '/src/pages/dataverse/index.scss';
 @import '/src/pages/dataverse/explore/explore.scss';


### PR DESCRIPTION
This PR adds the following features:

- Governance page
- redirection from home & dataset explore to governance page
- replaces the `governanceUrl` with governance data
- governance summary component
- adds a variant to the `PreviousPageButton`

The Page is internationalized.

<details>
<summary>Wide screen</summary>
url path: <b>home/explore/dataspace/[dataspaceId]/governance</b>

![Capture d’écran 2022-12-19 à 16 43 45](https://user-images.githubusercontent.com/75730728/208464972-e7521f09-bedd-4807-b508-1259c98616d9.png)

</details>
<details>
<summary>Medium screen</summary>
Dark theme

![Capture d’écran 2022-12-19 à 16 42 14](https://user-images.githubusercontent.com/75730728/208465216-0e69a9c3-ad4f-404e-a7ec-d203aeb148b3.png)

Light theme
![Capture d’écran 2022-12-19 à 16 42 19](https://user-images.githubusercontent.com/75730728/208465226-ea85fee6-7731-4d9f-8634-9359e7f5f740.png)

</details>
<details>
<summary>Small screen</summary>
Dark theme

![Capture d’écran 2022-12-19 à 16 43 14](https://user-images.githubusercontent.com/75730728/208465349-e6b3fc8e-05a8-4820-bafc-1a383bdb8893.png)

Light theme
![Capture d’écran 2022-12-19 à 16 43 07](https://user-images.githubusercontent.com/75730728/208465344-94b4bfa3-dba8-49ec-b927-c0e340cbf846.png)


</details>
<details>
<summary>Internationalization</summary>

<details>
<summary>English</summary>

![Capture d’écran 2022-12-20 à 14 26 53](https://user-images.githubusercontent.com/75730728/208678103-9fa7a145-85d2-4da8-bf73-94f65dae13cd.png)
</details>

<details>
<summary>French</summary>

![Capture d’écran 2022-12-20 à 14 26 23](https://user-images.githubusercontent.com/75730728/208678094-06239c39-fd84-4f00-9d51-b2d67f36acec.png)
</details>
</details>