### PR TITLE
feat(ui): handle dataspace card onClick handler

### DIFF
--- a/src/components/explore/exploreList/ExploreList.tsx
+++ b/src/components/explore/exploreList/ExploreList.tsx
@@ -55,9 +55,20 @@ const ExploreList = ({ entities, layout }: DeepReadonly<ExploreListProps>): JSX.
   const router: NextRouter = useRouter()
 
   const onListItemClick = useCallback(
-    (entity: DeepReadonly<DataverseEntity>) => async () =>
-      entity.type === 'dataset' &&
-      router.push(`/dataverse/explore/dataspace/${entity.dataspaceId}/${entity.type}/${entity.id}`),
+    (entity: DeepReadonly<DataverseEntity>) => () => {
+      switch (entity.type) {
+        case 'dataset':
+          router.push(
+            `/dataverse/explore/dataspace/${entity.dataspaceId}/${entity.type}/${entity.id}`
+          )
+          break
+        case 'dataspace':
+          router.push(`/dataverse/dataspace/${entity.id}/governance`)
+          break
+        default:
+          break
+      }
+    },
     [router]
   )
 


### PR DESCRIPTION
👉 In `explore` page, when clicking on a `dataspace` card, user is redirected to the governance page to visualize the dataspace rulebook.